### PR TITLE
libvirtcontroller: Changed domain name generation to be shorter

### DIFF
--- a/admin/fleetcommander/libvirtcontroller.py
+++ b/admin/fleetcommander/libvirtcontroller.py
@@ -236,7 +236,7 @@ class LibVirtController(object):
         root.find('uuid').text = newuuid
         # Change domain name
         name = root.find('name').text
-        root.find('name').text = '%s-fc-%s' % (name, newuuid)
+        root.find('name').text = '%s-fc-%s' % (name, newuuid[:8])
         # Change domain title
         try:
             title = root.find('title').text

--- a/tests/04_libvirt_controller.py
+++ b/tests/04_libvirt_controller.py
@@ -134,7 +134,8 @@ class TestLibVirtControllerSystemMode(unittest.TestCase):
 
         # Test new domain XML generation
         new_domain = ctrlr._last_started_domain
-        self.assertEqual(new_domain.XMLDesc(), libvirtmock.XML_MODIF % {'uuid': new_domain.UUIDString()})
+
+        self.assertEqual(new_domain.XMLDesc(), libvirtmock.XML_MODIF % {'name-uuid': new_domain.UUIDString()[:8], 'uuid': new_domain.UUIDString()})
 
         # Test SSH tunnel opening
         ctrlr._ssh_tunnel_prog.wait()  # Wait for process to finish

--- a/tests/data/libvirt_domain-modified.xml
+++ b/tests/data/libvirt_domain-modified.xml
@@ -1,5 +1,5 @@
 <domain xmlns:ns0="https://wiki.gnome.org/Apps/Boxes" id="4" type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
-  <name>fedora-unkno-fc-%(uuid)s</name>
+  <name>fedora-unkno-fc-%(name-uuid)s</name>
   <uuid>%(uuid)s</uuid>
   <title>Fedora - Fleet Commander temporary session</title>
   <metadata>


### PR DESCRIPTION
qemu Monitor path is built using domain name in Libvirt. We named machines as ORIGINAL_NAME-fc-LARGE_UUID.
qemu throws errors when Monitor path is too large making Libvirt to throw an error during VM creation.
To fix it I have shortened the LARGE_UUID to use only the first 8 characters.

