### PR TITLE
NetworkManager settings support for FleetCommander

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "admin/cockpit/fleet-commander-admin/js/spice-html5"]
 	path = admin/cockpit/fleet-commander-admin/js/spice-html5
-	url = https://github.com/SPICE/spice-html5
+	url = https://github.com/SPICE/spice-html5.git

--- a/admin/fleetcommander/collectors.py
+++ b/admin/fleetcommander/collectors.py
@@ -160,19 +160,17 @@ class NetworkManagerCollector(BaseCollector):
         """
         Return change key identifier for NM connection
         """
-        if 'connection' in change and 'uuid' in change['connection']:
-            return change['connection']['uuid']
+        try:
+            return change[u'json'][u'connection'][u'uuid']
+        except:
+            return
 
     def get_value_from_change(self, change):
         """
         Return change human readable value for NM connection
         """
-        if 'connection' in change and 'id' in change['connection']:
-            if 'type' in change['connection']:
-                return '%s - %s' % (
-                    change['connection']['type'],
-                    change['connection']['id'],
-                )
-            else:
-                return change['connection']['id']
-        return 'Undefined'
+        try:
+            conn = change[u'json'][u'connection']
+            return '%s - %s' % (conn[u'type'], conn[u'id']),
+        except:
+            return 'Undefined'

--- a/logger/fleet_commander_logger.js
+++ b/logger/fleet_commander_logger.js
@@ -294,6 +294,7 @@ var NMLogger = function (connmgr) {
 }
 
 NMLogger.prototype.security_filter = function (conn) {
+    conn = this.filter_variant (conn, ['connection', 'permissions']);
     conn = this.filter_variant (conn, ['vpn','data','secrets','Xauth password']);
     conn = this.filter_variant (conn, ['vpn','data','secrets','password']);
     conn = this.filter_variant (conn, ['802-1x','password']);

--- a/logger/fleet_commander_logger.js
+++ b/logger/fleet_commander_logger.js
@@ -91,7 +91,11 @@ function get_options_from_devfile () {
       debug ("Found server file in " + DEV_PATH + "fleet-commander_" + host + "-" + port);
 
       if (host == "localhost" || host == "127.0.0.1") {
-        let route = get_default_route ();
+        let route = null;
+        while (route == null) {
+          route = get_default_route ();
+          GLib.usleep (2000000);
+        }
         if (route) {
           debug ("Found " + host + " as admin host, using default route");
           host = route;
@@ -119,7 +123,10 @@ function get_default_route () {
 
   if (ipr.get_exit_status () != 0) {
     printerr ("There was an error calling ip to get the default route");
+  } else if (stdout == null) {
+    printerr ("There were no default routes, waiting for a default route to be available");
   } else {
+
     let routev = stdout.trim ().split (" ");
     if (routev.length > 2) {
       route = routev[2];

--- a/tests/03_logger_nm.js
+++ b/tests/03_logger_nm.js
@@ -160,10 +160,7 @@ function testNMVpn () {
 
     let conf = unmarshallVariant (payload.data);
     JsUnit.assertEquals (lookupString (conf, "vpn.user"), "foo");
-    JsUnit.assertEquals (lookupString (conf, "vpn.passwd"), "");
-
-    let secrets = unmarshallVariant(payload.secrets[0]);
-    JsUnit.assertEquals (lookupString (secrets, "vpn.passwd"), "asd");
+    JsUnit.assertEquals (lookupString (conf, "vpn.passwd"), "asd");
 }
 
 function testNMEthernet () {
@@ -174,9 +171,7 @@ function testNMEthernet () {
 
     let conf = unmarshallVariant (payload.data);
     JsUnit.assertEquals (lookupString (conf, "802-1x.user"), "foo");
-    JsUnit.assertEquals (lookupString (conf, "802-1x.passwd"), "");
-    let secrets = unmarshallVariant (payload.secrets[0]);
-    JsUnit.assertEquals (lookupString (secrets, "802-1x.passwd"), "asd");
+    JsUnit.assertEquals (lookupString (conf, "802-1x.passwd"), "asd");
 }
 
 function testNMWifi () {
@@ -187,9 +182,7 @@ function testNMWifi () {
 
     let conf = unmarshallVariant (payload.data);
     JsUnit.assertEquals (lookupString (conf, "802-11-wireless-security.user"), "foo");
-    JsUnit.assertEquals (lookupString (conf, "802-11-wireless-security.passwd"), "");
-    let secrets = unmarshallVariant (payload.secrets[0]);
-    JsUnit.assertEquals (lookupString (secrets, "802-11-wireless-security.passwd"), "asd");
+    JsUnit.assertEquals (lookupString (conf, "802-11-wireless-security.passwd"), "asd");
 }
 
 
@@ -211,11 +204,9 @@ function testFilters () {
 
   let vpnout = JSON.parse(item[1]);
   JsUnit.assertTrue  (vpnout instanceof Object);
-  for (let s in vpnout.secrets) {
-    let secret = unmarshallVariant (vpnout.secrets[s]);
-    JsUnit.assertEquals (lookupValue (secret, "vpn.data.secrets.password"), null);
-    JsUnit.assertEquals (lookupValue (secret, "vpn.data.secrets.Xauth password"), null);
-  }
+  let vpnconf = unmarshallVariant (vpnout.data);
+  JsUnit.assertEquals (lookupValue (vpnconf, "vpn.data.secrets.password"), null);
+  JsUnit.assertEquals (lookupValue (vpnconf, "vpn.data.secrets.Xauth password"), null);
 
   //Ethernet
   connmgr = setupNetworkConnection ("802-3-ethernet", {}, secrets);
@@ -225,10 +216,8 @@ function testFilters () {
 
   let ethout = JSON.parse(item[1]);
   JsUnit.assertTrue  (ethout instanceof Object);
-  for (let s in ethout.secrets) {
-    let eth_secrets = unmarshallVariant (ethout.secrets[s]);
-    JsUnit.assert (lookupValue(eth_secrets, "802-1x.password") == null);
-  }
+  let ethconf = unmarshallVariant (ethout.data);
+  JsUnit.assert (lookupValue(ethconf, "802-1x.password") == null);
 
   //Wifi
   connmgr = setupNetworkConnection ("802-11-wireless", {}, secrets);
@@ -236,11 +225,10 @@ function testFilters () {
 
   JsUnit.assertEquals (item[0], "org.freedesktop.NetworkManager");
   let wifiout = JSON.parse(item[1]);
-  for (let s in wifiout.secrets) {
-    let wifi_secrets = unmarshallVariant (wifiout.secrets[s]);
-    JsUnit.assert (lookupValue(wifi_secrets, "802-1x.password") == null);
-    JsUnit.assert (lookupValue(wifi_secrets, "802-11-wireless-security.leap-password") == null);
-  }
+  JsUnit.assertTrue  (wifiout instanceof Object);
+  let wificonf = unmarshallVariant (wifiout.data);
+  JsUnit.assert (lookupValue(wificonf, "802-1x.password") == null);
+  JsUnit.assert (lookupValue(wificonf, "802-11-wireless-security.leap-password") == null);
 }
 
 // Run test suite //


### PR DESCRIPTION
This branch adds support for NetworkManager by logging settings and encoding them in a little endian base64 string inside the json payload. The configuration blob is also represented as json for convenience but that data is ignored by the client side.

To test this the wip/networkmanager branch of fc-client is needed.