### PR TITLE
logger: store dconf data as a GVariant print() string

### DIFF
--- a/logger/fleet_commander_logger.js
+++ b/logger/fleet_commander_logger.js
@@ -636,7 +636,7 @@ GSettingsLogger.prototype._libreoffice_change = function(path, keys) {
     builder.set_member_name("key");
     builder.add_string_value(path + key);
     builder.set_member_name("value");
-    builder.add_value(Json.gvariant_serialize(variant));
+    builder.add_string_value(variant.print (true));
     builder.set_member_name("signature");
     builder.add_string_value(variant.get_type_string());
     builder.end_object();
@@ -663,7 +663,7 @@ GSettingsLogger.prototype._settings_changed = function(schema, settings, keys) {
         builder.set_member_name("schema");
         builder.add_string_value(schema.get_id());
         builder.set_member_name("value");
-        builder.add_value(Json.gvariant_serialize(variant));
+        builder.add_string_value(variant.print (true));
         builder.set_member_name("signature");
         builder.add_string_value(variant.get_type().dup_string());
         builder.end_object();

--- a/tests/_01_logger_test_suite.js
+++ b/tests/_01_logger_test_suite.js
@@ -94,7 +94,7 @@ function testGSettingsLoggerWriteKeyForKnownSchema () {
   JsUnit.assertEquals(change[0], "org.gnome.gsettings");
 
   // we normalize the json object using the same parser
-  JsUnit.assertEquals(JSON.stringify({'key':'/test/test', 'schema':'fleet-commander-test','value':true,'signature':'b'}),
+  JsUnit.assertEquals(JSON.stringify({'key':'/test/test', 'schema':'fleet-commander-test','value': 'true','signature':'b'}),
                       JSON.stringify(JSON.parse(change[1])));
 
   Gio.DBus.get_sync (Gio.BusType.SESSION, null).signal_unsubscribe (glog.dconf_subscription_id);
@@ -124,7 +124,7 @@ function testGSettingsLoggerWriteKeyForGuessableSchema () {
   JsUnit.assertEquals(change[0], "org.gnome.gsettings");
   JsUnit.assertEquals(JSON.stringify({'key':'/reloc/foo/fc-unique',
                                        'schema':'fleet-commander-reloc1',
-                                       'value':true,
+                                       'value': 'true',
                                        'signature':'b'}),
                       JSON.stringify(JSON.parse(change[1])));
   Gio.DBus.get_sync (Gio.BusType.SESSION, null).signal_unsubscribe (glog.dconf_subscription_id);
@@ -143,7 +143,7 @@ function testGSettingsLoggerGuessSchemaCachedPath () {
   JsUnit.assertEquals(change[0], "org.gnome.gsettings");
   JsUnit.assertEquals(JSON.stringify({'key':'/reloc/foo/fc-common',
                                        'schema':'fleet-commander-reloc1',
-                                       'value':true,
+                                       'value': 'true',
                                        'signature':'b'}),
                       JSON.stringify(JSON.parse(change[1])));
 
@@ -165,7 +165,7 @@ function testLibreOfficeLoggerWriteKey () {
   JsUnit.assertEquals(change[0], "org.libreoffice.registry");
 
   // we normalize the json object using the same parser
-  JsUnit.assertEquals(JSON.stringify({'key':'/org/libreoffice/registry/somepath/somekey', 'value':123,'signature':'i'}),
+  JsUnit.assertEquals(JSON.stringify({'key':'/org/libreoffice/registry/somepath/somekey', 'value': '123','signature':'i'}),
                       JSON.stringify(JSON.parse(change[1])));
 
   Gio.DBus.get_sync (Gio.BusType.SESSION, null).signal_unsubscribe (glog.dconf_subscription_id);


### PR DESCRIPTION
Switch to GVariant print() for greater reliability. Test with fc-client branch of the same name (wip/variantdata-gsettings)