### PR TITLE
data: Add AppStream metainfo

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -20,13 +20,17 @@ fleet_commander_dbus_shellwrapperdir = ${libexecdir}
 fleet_commander_dbus_shellwrapper_in_files = fleet-commander-admin.in
 fleet_commander_dbus_shellwrapper_DATA = fleet-commander-admin
 
+fleet_commander_metainfodir = ${datarootdir}/metainfo
+fleet_commander_metainfo_DATA = org.freedesktop.FleetCommander.admin.metainfo.xml
+
 EXTRA_DIST = \
 	$(fleet_commander_logger_desktop_in_files)     \
 	$(fleet_commander_admin_config_in_files)       \
 	$(fleet_commander_dbus_service_in_files)       \
 	$(fleet_commander_goa_providers_DATA)          \
 	$(fleet_commander_udev_rules_DATA)             \
-	$(fleet_commander_dbus_shellwrapper_in_files)
+	$(fleet_commander_dbus_shellwrapper_in_files)  \
+	$(fleet_commander_metainfo_DATA)
 
 CLEANFILES = \
 	$(fleet_commander_logger_desktop_DATA)      \

--- a/data/org.freedesktop.FleetCommander.admin.metainfo.xml
+++ b/data/org.freedesktop.FleetCommander.admin.metainfo.xml
@@ -1,0 +1,18 @@
+<component type="addon">
+  <id>org.freedesktop.FleetCommander.admin</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Fleet Commander</name>
+  <summary>
+    Manage desktop configuration for a large network
+  </summary>
+  <description>
+    <p>
+      Fleet Commander is an application that allows you to manage the
+      desktop configuration of a large network of users and
+      workstations/laptops. It is primarily targeted to Linux systems
+      based on the GNOME desktop.
+    </p>
+  </description>
+  <extends>cockpit.desktop</extends>
+  <launchable type="cockpit-manifest">fleet-commander-admin</launchable>
+</component>


### PR DESCRIPTION
This makes the Fleet Commander admin interface appear as an
installable application inside Cockpit.