### PR TITLE
Fix/logger chromium policies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(fleet-commander-admin, 0.10.8, aruiz@redhat.com)
+AC_INIT(fleet-commander-admin, 0.10.9, aruiz@redhat.com)
 AC_COPYRIGHT([Copyright 2014,2015,2016,2017,2018 Red Hat, Inc.])
 
 AC_PREREQ(2.64)

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -726,14 +726,17 @@ class ChromiumLogger(object):
         """
         policy_map = None
         for dirpath in GLib.get_system_data_dirs():
-            logging.debug("Looking for chromium policies file at %s" % dirpath);
+            logging.debug("Looking for chromium policies file at %s" % dirpath)
+            filepath = os.path.join(dirpath, 'fleet-commander-logger/fc-chromium-policies.json')
             try:
-                filepath = os.path.join(dirpath, 'fleet-commander-logger/fc-chromium-policies.json')
-                contents = GLib.file_get_contents(filepath)[1];
-                policy_map = json.loads(contents)
-                break;
+                with open(filepath, 'r') as fd:
+                    contents = fd.read()
+                    policy_map = json.loads(contents)
+                    fd.close()
+                logging.debug('Loaded chromium policies file at %s' % filepath)
+                break
             except Exception as e:
-                pass
+                logging.debug('Can not open chromium policies file at %s: %s' % (filepath, e))
         return policy_map
 
     def _setup_local_state_file_monitor(self):

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -90,7 +90,11 @@ class SpicePortManager(object):
         self.queue = []
         self.timeout = 0
 
-        self.fd = open(self.path, 'wb', 0)
+        try:
+            self.fd = open(self.path, 'wb', 0)
+        except FileNotFoundError as e:
+            logging.error('Can\'t open device file %s. Use -n or --no-dev for non Fleet Commander VM session' % self.path)
+            sys.exit(1)
 
     def _perform_submits(self):
         if len(self.queue) < 1:


### PR DESCRIPTION
Fixed also the unhandled exception when the device file does not exist and try to execute logger without using  -n or --no-device . https://retrace.fedoraproject.org/faf/reports/2230823/