### PR TITLE
[Py3] Remove dependency on gobject

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,6 @@ fi
 AM_PATH_PYTHON([2],, [:])
 AC_PYTHON_MODULE([pexpect], [mandatory])
 AC_PYTHON_MODULE([dbus], [mandatory])
-AC_PYTHON_MODULE([gobject], [mandatory])
 AC_PYTHON_MODULE([gi], [mandatory])
 AC_PYTHON_MODULE([libvirt], [mandatory])
 AC_PYTHON_MODULE([dbusmock])

--- a/package-requirements.txt
+++ b/package-requirements.txt
@@ -1,7 +1,6 @@
 autoconf
 automake
 autoconf-archive
-pygobject2
 libvirt-python
 python-dbusmock
 python-gobject


### PR DESCRIPTION
fc-admin no longer uses the gobject package. The last "import gobject"
was removed in commit 1710278761c8b80ee19c2cc357d287ebd49e7c55. Instead
of gobject, fc-admin has been using the 'gi' package.

Fedora doesn't have pygobject2 for Python 3. The python3-gobject package
provides gi bindings.

Signed-off-by: Christian Heimes <cheimes@redhat.com>