### PR TITLE
Prepared environment to be able to test Python 2 and 3 by changing it at config stage

### DIFF
--- a/tests/00_database.py
+++ b/tests/00_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/00_freeipa.py
+++ b/tests/00_freeipa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/00_sshcontroller.py
+++ b/tests/00_sshcontroller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/01_logger_dconf.sh
+++ b/tests/01_logger_dconf.sh
@@ -50,10 +50,10 @@ kill $DBUS_SESSION_BUS_PID
 eval `dbus-launch`
 export DBUS_SESSION_BUS_ADDRESS
 
-$TOPSRCDIR/tests/_01_mock_dbus.py > /dev/null 2> /dev/null &
+$PYTHON $TOPSRCDIR/tests/_01_mock_dbus.py > /dev/null 2> /dev/null &
 DBUS_MOCK_PID=$!
 
-$TOPSRCDIR/tests/_01_wait_for_name.py
+$PYTHON $TOPSRCDIR/tests/_01_wait_for_name.py
 if [ $? -ne 0 ] ; then
   echo "Failed to acquire bus name org.freedesktop.ScreenSaver"
   exit 1
@@ -65,7 +65,7 @@ if [ $? -ne 0 ] ; then
   exit 1
 fi
 
-$TOPSRCDIR/tests/_01_logger_test_suite.py
+$PYTHON $TOPSRCDIR/tests/_01_logger_test_suite.py
 RET=$?
 
 rm -rf $GSETTINGS_SCHEMA_DIR

--- a/tests/01_mergers.py
+++ b/tests/01_mergers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/02_logger_connmgr.py
+++ b/tests/02_logger_connmgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/03_logger_chromium.py
+++ b/tests/03_logger_chromium.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/03_logger_firefox.py
+++ b/tests/03_logger_firefox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/03_logger_nm.py
+++ b/tests/03_logger_nm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/04_libvirt_controller.py
+++ b/tests/04_libvirt_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!./python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/05_fcdbus.sh
+++ b/tests/05_fcdbus.sh
@@ -31,7 +31,7 @@ eval `dbus-launch`
 export DBUS_SESSION_BUS_ADDRESS
 
 # Execute fleet commander dbus service tests
-$TOPSRCDIR/tests/_05_fcdbus_tests.py
+$PYTHON $TOPSRCDIR/tests/_05_fcdbus_tests.py
 RET=$?
 
 kill $DBUS_SESSION_BUS_PID

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,8 @@
-TESTS_ENVIRONMENT = export PATH=$(abs_top_srcdir)/tests/tools:$(PATH); export TOPSRCDIR=$(abs_top_srcdir); export GJS_PATH=$(abs_top_srcdir)/logger; export FC_TESTING=true; export XDG_DATA_DIRS=$(abs_top_srcdir)/tests/data/;
+TESTS_ENVIRONMENT = export PATH=$(abs_top_srcdir)/tests/tools:$(PATH); export TOPSRCDIR=$(abs_top_srcdir); export GJS_PATH=$(abs_top_srcdir)/logger; export FC_TESTING=true; export XDG_DATA_DIRS=$(abs_top_srcdir)/tests/data/; export PYTHON=@PYTHON@;
 TESTS = 00_database.py 00_freeipa.py 00_sshcontroller.py 01_mergers.py 01_logger_dconf.sh 02_logger_connmgr.py 03_logger_nm.py 03_logger_chromium.py 03_logger_firefox.py 04_libvirt_controller.py 05_fcdbus.sh
 
-EXTRA_DIST =                       \
+
+EXTRA_DIST =                         \
 	$(TESTS)                         \
 	freeipamock.py                   \
 	libvirtmock.py                   \

--- a/tests/_01_logger_test_suite.py
+++ b/tests/_01_logger_test_suite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/_01_mock_dbus.py
+++ b/tests/_01_mock_dbus.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 import dbus.service
 import dbusmock
 import dbus.mainloop.glib

--- a/tests/_01_wait_for_name.py
+++ b/tests/_01_wait_for_name.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 import dbus
 import time
 import sys

--- a/tests/_05_fcdbus_tests.py
+++ b/tests/_05_fcdbus_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # vi:ts=4 sw=4 sts=4
 
@@ -112,6 +111,7 @@ class TestDbusService(unittest.TestCase):
 
         # Open service
         self.service = subprocess.Popen([
+            os.environ['PYTHON'],
             os.path.join(
                 os.environ['TOPSRCDIR'],
                 'tests/test_fcdbus_service.py'),

--- a/tests/freeipamock.py
+++ b/tests/freeipamock.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/libvirtmock.py
+++ b/tests/libvirtmock.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/python-wrapper.sh
+++ b/tests/python-wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/env bash
+exec "$PYTHON" "$@"

--- a/tests/test_fcdbus_service.py
+++ b/tests/test_fcdbus_service.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # vi:ts=4 sw=4 sts=4
 


### PR DESCRIPTION
The environment has been modified to use PYTHON variable to specify what interpreter to use:

    PYTHON=python2 ./configure

or

    PYTHON=python3 ./configure
