### PR TITLE
libvirtcontroller: use 'qxl' instead of 'virtio' as video type

### DIFF
--- a/admin/fleetcommander/libvirtcontroller.py
+++ b/admin/fleetcommander/libvirtcontroller.py
@@ -225,7 +225,7 @@ class LibVirtController(object):
         model = ET.SubElement(video, 'model')
         model.set('heads', '1')
         model.set('primary', 'yes')
-        model.set('type', 'virtio')
+        model.set('type', 'qxl')
         # Remove all graphics adapters and create our own
         for elem in devs.findall('graphics'):
             devs.remove(elem)


### PR DESCRIPTION
'virtio' video device is not part of CentOS7 and when trying to start a
VM QEMU will bail out with:

libvirtd[8345]: 2018-08-21 10:55:30.602+0000: 8349: error :
qemuProcessStartValidateVideo:4692 : unsupported configuration: this
QEMU does not support 'virtio' video device

Although the device type is available on recent Fedora and RHEL
versions, would be safer to use 'qxl' and also smoothly support CentOS7.

Resolves:
https://github.com/fleet-commander/fc-admin/issues/193

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>