### PR TITLE
fcdbus: raise an exception in case the user's home is not created

### DIFF
--- a/admin/fleetcommander/fcdbus.py
+++ b/admin/fleetcommander/fcdbus.py
@@ -193,7 +193,15 @@ class FleetCommanderDbusService(dbus.service.Object):
                 self.home_dir, '.local/share/fleetcommander')
 
         if not os.path.exists(self.state_dir):
-            os.makedirs(self.state_dir)
+            raise Exception(
+                '%s directory does not exit.\n'
+                'In order to have the directory automatically created you '
+                'have the following options:\n'
+                '- install freeipa-server using `--mkenablehomedir`;\n'
+                '- call: `authconfig --enablemkhomedir --update`;\n'
+                '- call: `authselect select sssd with-mkhomedir`;\n'
+                'The user will have to log into the system in order to have '
+                'their home directory created!' % (self.home_dir))
 
         self.database_path = os.path.join(self.state_dir, 'fleetcommander.db')
 


### PR DESCRIPTION
The current code tries to create the user's home directory in case its
not yet created. However, as the fcdbus is ran as the user logged into
cockpit and not as root, trying to create the home directory is
something that will always fail.

Instead of trying to solve this misconfiguration issue by ourselves,
let's inform the user the paths they could take in order to properly fix
the issue.

Resolves:
https://github.com/fleet-commander/fc-admin/issues/192

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>