### PR TITLE
Fix logging to browser console

### DIFF
--- a/admin/cockpit/fleet-commander-admin/js/index.js
+++ b/admin/cockpit/fleet-commander-admin/js/index.js
@@ -490,7 +490,7 @@ $(document).ready (function () {
       state.debuglevel = resp.debuglevel
       state.defaults = resp.defaults
 
-      setDebugLevel(resp.debugLevel);
+      setDebugLevel(resp.debuglevel);
 
       // Try FreeIPA connection
       fc.DoIPAConnection(function(resp) {

--- a/admin/cockpit/fleet-commander-admin/js/livesession.js
+++ b/admin/cockpit/fleet-commander-admin/js/livesession.js
@@ -256,7 +256,7 @@ $(document).ready (function () {
   fc = new FleetCommanderDbusClient(function(){
 
     fc.GetInitialValues(function(resp) {
-      setDebugLevel(resp.debugLevel);
+      setDebugLevel(resp.debuglevel);
 
       // Try FreeIPA connection
       fc.DoIPAConnection(function(resp) {


### PR DESCRIPTION
Actually, log level is taken from FC config via DBus method
"GetInitialValues" having spec:
```
state = {
    'debuglevel': self.log_level,
    'defaults': {
        'profilepriority': self.default_profile_priority,
    }
}
```

So, actually, there is a typo debugLevel => debuglevel.

Fixes: https://github.com/fleet-commander/fc-admin/issues/214