### PR TITLE
Add Dialog classes

### DIFF
--- a/admin/Makefile.am
+++ b/admin/Makefile.am
@@ -20,6 +20,7 @@ fc_js_DATA = \
 	cockpit/fleet-commander-admin/js/jquery-3.3.1.min.js \
 	cockpit/fleet-commander-admin/js/bootstrap-4.0.0.min.js \
 	cockpit/fleet-commander-admin/js/base.js \
+	cockpit/fleet-commander-admin/js/dialogs.js \
 	cockpit/fleet-commander-admin/js/fcdbusclient.js \
 	cockpit/fleet-commander-admin/js/fcspiceclient.js \
 	cockpit/fleet-commander-admin/js/collectors.js \

--- a/admin/cockpit/fleet-commander-admin/index.html
+++ b/admin/cockpit/fleet-commander-admin/index.html
@@ -13,6 +13,7 @@
 
       <link href="css/main.css" type="text/css" rel="stylesheet">
       <script src="js/base.js"></script>
+      <script src="js/dialogs.js"></script>
       <script src="js/fcdbusclient.js"></script>
       <script src="js/index.js"></script>
       <script src="js/highlightedapps.js"></script>
@@ -330,6 +331,24 @@
 
     <!-- Message dialog modal -->
     <div id="message-dialog-modal" class="modal fade" tabindex='-1'>
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title"></h4>
+          </div>
+
+          <div class="modal-body">
+          </div>
+
+          <div class="modal-footer">
+            <button class="btn btn-default" data-dismiss="modal" translatable="yes">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Question dialog modal -->
+    <div id="question-dialog-modal" class="modal fade" tabindex='-1'>
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">

--- a/admin/cockpit/fleet-commander-admin/js/base.js
+++ b/admin/cockpit/fleet-commander-admin/js/base.js
@@ -22,69 +22,6 @@
  * Utility functions
  ******************************************************************************/
 
-function showMessageDialog(message, title, closecb) {
-  title = title || 'Info';
-  var dialog = $('#message-dialog-modal');
-  closecb = closecb || function() { dialog.modal('hide') }
-  $('#message-dialog-modal h4').html(title);
-  $('#message-dialog-modal .modal-body').html(message);
-  var modal_footer = $('#message-dialog-modal .modal-footer');
-  modal_footer.html('');
-  var closebutton =  $('<button></button>', {"class": "btn btn-primary", text: _('Close')})
-    .click(closecb)
-    .appendTo(modal_footer);
-  dialog.modal('show');
-}
-
-function showQuestionDialog(message, title, acceptcb, cancelcb) {
-  title = title || _('Question');
-  var dialog = $('#message-dialog-modal');
-  cancelcb = cancelcb || function() { dialog.modal('hide') }
-  $('#message-dialog-modal h4').html(title);
-  $('#message-dialog-modal .modal-body').html(message);
-  var modal_footer = $('#message-dialog-modal .modal-footer');
-  modal_footer.html('');
-  var cancelbutton =  $('<button></button>', {"class": "btn btn-default", text: _('Cancel')})
-    .click(cancelcb)
-    .appendTo(modal_footer);
-  var acceptbutton =  $('<button></button>', {"class": "btn btn-primary", text: _('Ok')})
-    .click(acceptcb)
-    .appendTo(modal_footer);
-  dialog.modal('show');
-}
-
-function showSpinnerDialog(message, title) {
-  title = title || _('Loading');
-  $('#spinner-dialog-modal h4').html(title);
-  $('#spinner-dialog-modal .modal-body p').html(message);
-  $('#spinner-dialog-modal').modal('show');
-}
-
-function showCurtain(message, title, icon, buttons) {
-  icon = icon || 'exclamation-circle'
-  buttons = buttons || {}
-  $('#curtain h1').html(title);
-  $('#curtain p').html(message);
-  var iconarea = $('#curtain .blank-slate-pf-icon');
-  if (icon != 'spinner') {
-    iconarea.html('<i class="fa fa-' + icon + '"></i>')
-  } else {
-    iconarea.html('<div class="spinner spinner-lg"></div>')
-  }
-  // TODO: Manage buttons
-  buttonsarea = $('#curtain .blank-slate-pf-main-action');
-  buttonsarea.html('');
-  $.each(buttons, function(id, data){
-    var btnclass = data.class || 'btn-default';
-    var button = $('<button id="' + id + '" class="btn btn-lg ' +
-      btnclass + '">' + data.text + '</button>');
-    button.click(data.callback);
-    buttonsarea.append(button);
-    buttonsarea.append(' ');
-  })
-  $('#curtain').show();
-}
-
 function clearModalFormErrors(modalId) {
   $('#' + modalId + ' div.form-group').removeClass('has-error');
   $('#' + modalId + ' div.form-group > .error-message').remove();

--- a/admin/cockpit/fleet-commander-admin/js/dialogs.js
+++ b/admin/cockpit/fleet-commander-admin/js/dialogs.js
@@ -1,0 +1,166 @@
+//
+// Copyright (C) 2019  FleetCommander Contributors see COPYING for license
+//
+
+/*******************************************************************************
+ * Dialogs
+ ******************************************************************************/
+
+// actual creation happens on doc ready
+var spinnerDialog = null;
+var questionDialog = null;
+var messageDialog = null;
+
+function BaseDialog(id) {
+  var self = this;
+  this.id = id;
+  /* state can be 'hide', 'show' or 'notset' */
+  this.state = 'hide';
+  var hidn_ev = 'hidden.bs.modal';
+  var shn_ev = 'shown.bs.modal';
+
+  $(this.id).off(hidn_ev).on(hidn_ev, function () {
+    if (self.state === 'show') {
+      $(this).modal('show');
+    }
+    self.state = 'notset';
+  });
+
+  $(this.id).off(shn_ev).on(shn_ev, function () {
+    if (self.state === 'hide') {
+      $(this).modal('hide');
+    }
+    self.state = 'notset';
+  });
+};
+
+BaseDialog.prototype = {
+  show: function() {
+    this.state = 'show';
+    $(this.id).modal('show');
+  },
+  close: function() {
+    this.state = 'hide';
+    $(this.id).modal('hide');
+  }
+};
+
+function SpinnerDialog() {
+  var id = '#spinner-dialog-modal';
+  var default_title = _('Loading');
+  BaseDialog.apply(this, [id]);
+
+  this.show = function(message, title) {
+    title = title || default_title;
+    $(id + ' h4').html(title);
+    $(id + ' .modal-body p').html(message);
+    BaseDialog.prototype.show.apply(this);
+  };
+};
+
+SpinnerDialog.prototype = Object.create(BaseDialog.prototype);
+SpinnerDialog.prototype.constructor = SpinnerDialog;
+
+function QuestionDialog() {
+  var self = this;
+  var id = '#question-dialog-modal';
+  var default_title = _('Question');
+  BaseDialog.apply(this, [id]);
+
+  this.show = function(message, title, acceptcb, cancelcb) {
+    title = title || default_title;
+    cancelcb = cancelcb || function() { self.close(); };
+    $(id + ' h4').html(title);
+    $(id + ' .modal-body').html(message);
+    $(id + ' .modal-footer').html('');
+    $(
+      '<button/>',
+      {
+        class: 'btn btn-default',
+        text: _('Cancel')
+      }
+    )
+    .click(cancelcb)
+    .appendTo(id + ' .modal-footer');
+    $(
+      '<button/>',
+      {
+        class: 'btn btn-primary',
+        text: _('Ok')
+      }
+    )
+    .click(acceptcb)
+    .appendTo(id + ' .modal-footer');
+
+    $(id).off('keypress').keypress(function(e) {
+      var code = (e.keyCode ? e.keyCode : e.which);
+      if(code == 13) {
+        acceptcb();
+      }
+    });
+    BaseDialog.prototype.show.apply(this);
+  };
+};
+
+QuestionDialog.prototype = Object.create(BaseDialog.prototype);
+QuestionDialog.prototype.constructor = QuestionDialog;
+
+function MessageDialog() {
+  var self = this;
+  var id = '#message-dialog-modal';
+  var default_title = _('Info');
+  BaseDialog.apply(this, [id]);
+
+  this.show = function(message, title, closecb) {
+    title = title || default_title;
+    closecb = closecb || function() { self.close(); };
+    $(id + ' h4').html(title);
+    $(id + ' .modal-body').html(message);
+    $(id + ' .modal-footer').html('');
+    $(
+      '<button/>',
+      {
+	class: 'btn btn-primary',
+	text: _('Close')
+      }
+    )
+    .click(closecb)
+    .appendTo(id + ' .modal-footer');
+
+    $(id).off('keypress').keypress(function(e) {
+      var code = (e.keyCode ? e.keyCode : e.which);
+      if(code == 13) {
+        closecb();
+      }
+    });
+    BaseDialog.prototype.show.apply(this);
+  };
+};
+
+MessageDialog.prototype = Object.create(BaseDialog.prototype);
+MessageDialog.prototype.constructor = MessageDialog;
+
+function showCurtain(message, title, icon, buttons) {
+  icon = icon || 'exclamation-circle';
+  buttons = buttons || {};
+  $('#curtain h1').html(title);
+  $('#curtain p').html(message);
+  var iconarea = $('#curtain .blank-slate-pf-icon');
+  if (icon != 'spinner') {
+    iconarea.html('<i class="fa fa-' + icon + '"></i>');
+  } else {
+    iconarea.html('<div class="spinner spinner-lg"></div>');
+  }
+  // TODO: Manage buttons
+  buttonsarea = $('#curtain .blank-slate-pf-main-action');
+  buttonsarea.html('');
+  $.each(buttons, function(id, data){
+    var btnclass = data.class || 'btn-default';
+    var button = $('<button id="' + id + '" class="btn btn-lg ' +
+      btnclass + '">' + data.text + '</button>');
+    button.click(data.callback);
+    buttonsarea.append(button);
+    buttonsarea.append(' ');
+  })
+  $('#curtain').show();
+}

--- a/admin/cockpit/fleet-commander-admin/js/fcspiceclient.js
+++ b/admin/cockpit/fleet-commander-admin/js/fcspiceclient.js
@@ -39,15 +39,18 @@ function FleetCommanderSpiceClient(host, port, error_cb, timeout) {
         self.connecting = null;
         self.noretry = true;
         DEBUG > 0 && console.log('FC: Connection tries timed out');
-        $('#spinner-dialog-modal').modal('hide');
-        showMessageDialog(_('Connection error to virtual machine.'), _('Connection error'));
+        spinnerDialog.close();
+        messageDialog.show(
+          _('Connection error to virtual machine.'),
+          _('Connection error')
+        );
       }, self.conn_timeout);
     }
   }
 
   this.spice_connected = function() {
     DEBUG > 0 && console.log('FC: Connected to virtual machine using SPICE');
-    $('#spinner-dialog-modal').modal('hide');
+    spinnerDialog.close();
     if (self.connecting) {
       clearTimeout(self.connecting);
       self.connecting = null;
@@ -65,22 +68,27 @@ function FleetCommanderSpiceClient(host, port, error_cb, timeout) {
             err.message == 'Connection timed out.' ||
             self.sc.state != 'ready')  {
           if (!self.noretry) {
-            showSpinnerDialog(
+            spinnerDialog.show(
               _('Connecting to virtual machine. Please wait...'),
-              _('Reconnecting'))
+              _('Reconnecting')
+	    );
             self.do_connection();
           }
           return
         } else {
-          showMessageDialog(
-            'Connection error to virtual machine', 'Connection error');
+          messageDialog.show(
+            _('Connection error to virtual machine'),
+            _('Connection error')
+          );
         }
       } else {
-        showMessageDialog(
-          'Virtual machine has been stopped', 'Connection error');
+        messageDialog.show(
+          _('Virtual machine has been stopped'),
+          _('Connection error')
+        );
       }
 
-      $('#spinner-dialog-modal').modal('hide');
+      spinnerDialog.close();
       if (self.connecting) {
         clearTimeout(self.connecting);
         self.connecting = null;
@@ -126,9 +134,9 @@ function FleetCommanderSpiceClient(host, port, error_cb, timeout) {
   }
 
   this.reconnect = function() {
-    showSpinnerDialog(
+    spinnerDialog.show(
       _('Connecting to virtual machine. Please wait...'),
-      _('Reconnecting'))
+      _('Reconnecting'));
     self.do_connection();
   }
 

--- a/admin/cockpit/fleet-commander-admin/js/goa.js
+++ b/admin/cockpit/fleet-commander-admin/js/goa.js
@@ -109,13 +109,15 @@ function showGOAAccountEdit(account_id) {
 }
 
 function removeGOAAccount(account_id) {
-  showQuestionDialog(
+  questionDialog.show(
     _('Are you sure you want remove "' + account_id + '"?'),
-    _('Remove GOA account confirmation'),function() {
+    _('Remove GOA account confirmation'),
+    function() {
       delete current_goa_accounts[account_id];
-      $('#message-dialog-modal').modal('hide');
+      questionDialog.close();
       populateGOAAccounts();
-    });
+    }
+  );
 }
 
 function updateProviderServices() {
@@ -158,7 +160,7 @@ function updateOrAddGOAAccount() {
   });
 
   if (repeated) {
-    showMessageDialog(
+    messageDialog.show(
       _('There exists another account for provider ') + provider,
       _('Error'))
       return
@@ -236,10 +238,11 @@ function initialize_goa() {
         showGOAAccounts();
       });
     } else {
-      showMessageDialog(
+      messageDialog.show(
         _('Error loading GOA providers. GOA support will not be available'),
-        _('Error'))
-        $('#show-goa-accounts').hide();
+        _('Error')
+      );
+      $('#show-goa-accounts').hide();
     }
   });
 }

--- a/admin/cockpit/fleet-commander-admin/js/highlightedapps.js
+++ b/admin/cockpit/fleet-commander-admin/js/highlightedapps.js
@@ -63,13 +63,22 @@ function addHighlightedAppFromEntry () {
   var app = $('#app-name').val ();
 
   if (hasSuffix(app, ".desktop") == false) {
-    showMessageDialog(_('Application identifier must have .desktop extension'), _('Invalid entry'));
+    messageDialog.show(
+      _('Application identifier must have .desktop extension'),
+      _('Invalid entry')
+    );
     return
   } else if (app.indexOf('"') != -1 || app.indexOf("'") != -1) {
-    showMessageDialog(_('Application identifier must not contain quotes'), _('Invalid entry'));
+    messageDialog.show(
+      _('Application identifier must not contain quotes'),
+      _('Invalid entry')
+    );
     return
   } else if ($('#highlighted-apps-list li[data-id="' + app + '"]').length > 0) {
-    showMessageDialog(_('Application identifier is already in favourites'), _('Invalid entry'));
+    messageDialog.show(
+      _('Application identifier is already in favourites'),
+      _('Invalid entry')
+    );
     return
   }
   addHighlightedApp(app);
@@ -90,7 +99,10 @@ function saveHighlightedAppsOld () {
       $('#highlighted-apps-modal').modal('hide');
       $('#profile-modal').modal('show');
     } else {
-      showMessageDialog(_('Error saving highlighted apps'), _('Error'));
+      messageDialog.show(
+        _('Error saving highlighted apps'),
+        _('Error')
+      );
     }
   });
 }

--- a/admin/cockpit/fleet-commander-admin/js/livesession.js
+++ b/admin/cockpit/fleet-commander-admin/js/livesession.js
@@ -45,7 +45,9 @@ window.alert = function(message) {
 }
 
 function startLiveSession() {
-  showSpinnerDialog(_('Connecting to virtual machine'))
+  spinnerDialog.show(
+    _('Connecting to virtual machine')
+  );
   // Stop any previous session
   stopLiveSession(function(){
     var domain = sessionStorage.getItem("fc.session.domain")
@@ -57,8 +59,8 @@ function startLiveSession() {
           });
         startHeartBeat();
       } else {
-        showMessageDialog(resp.error, _('Error'));
-        $('#spinner-dialog-modal').modal('hide');
+        messageDialog.show(resp.error, _('Error'));
+        spinnerDialog.close();
       }
     })
   });
@@ -229,9 +231,10 @@ function deployProfile() {
       collectors['org.freedesktop.NetworkManager'].get_changeset(networkmanager)
   };
 
-  showSpinnerDialog(
+  spinnerDialog.show(
     _('Saving settings to profile. Please wait...'),
-    _('Saving settings'))
+    _('Saving settings')
+  );
 
   $('#event-logs').modal('hide');
 
@@ -243,8 +246,11 @@ function deployProfile() {
           DEBUG > 0 && console.log('FC: Saved live session settings')
           location.href='index.html'
         } else {
-          showMessageDialog(_('Error saving session'), _('Error'));
-          $('#spinner-dialog-modal').modal('hide');
+          messageDialog.show(
+            _('Error saving session'),
+            _('Error')
+          );
+          spinnerDialog.close();
         }
     }, function(){
       console.log('FC: Error saving live session settings')
@@ -258,6 +264,8 @@ $(document).ready (function () {
   $('#review-changes').click(reviewAndSubmit);
   $('#deploy-profile').click(deployProfile);
 
+  spinnerDialog = new SpinnerDialog();
+  messageDialog = new MessageDialog();
 
   // SPICE port changes listeners
   window.addEventListener('spice-port-data', function(event) {

--- a/admin/cockpit/fleet-commander-admin/livesession.html
+++ b/admin/cockpit/fleet-commander-admin/livesession.html
@@ -43,6 +43,7 @@
 
     <link href="css/main.css" type="text/css" rel="stylesheet">
     <script src="js/base.js"></script>
+    <script src="js/dialogs.js"></script>
     <script src="js/fcdbusclient.js"></script>
     <script src="js/fcspiceclient.js"></script>
     <script src="js/collectors.js"></script>


### PR DESCRIPTION
As for now, there are several basic methods for operating common
dialogs. These methods include only the display of such messages.
For the other actions, the caller of dialog has to do it in his
own way. For example, there is no central point for closing or
event handling.

This patch adds base dialog class and several derived. Now we can
easily manage spinner, question and message dialogs in one place.

Fixes: https://github.com/fleet-commander/fc-admin/issues/222