### PR TITLE
Add explicit error message for realmd

### DIFF
--- a/admin/fleetcommander/fcdbus.py
+++ b/admin/fleetcommander/fcdbus.py
@@ -184,6 +184,14 @@ class FleetCommanderDbusService(dbus.service.Object):
             'org.freedesktop.realmd.Provider',
             None)
         realms = sssd_provider.get_cached_property('Realms')
+
+        if realms is None:
+            logging.error(
+                'It seems that "realmd" package is not installed.'
+                ' "realmd" is used for retreiving information about the Realm.'
+            )
+            sys.exit(1)
+
         if len(realms) > 0:
             logging.debug(
                 'FC: realmd queried. Using realm object %s' % realms[0])


### PR DESCRIPTION
As for now if the realmd package is not installed then an error
happens. But the reason for this error is not obvious.

Fixes: https://github.com/fleet-commander/fc-admin/issues/224