### PR TITLE
Fill up currentuid on adding a new profile

### DIFF
--- a/admin/cockpit/fleet-commander-admin/js/index.js
+++ b/admin/cockpit/fleet-commander-admin/js/index.js
@@ -244,6 +244,7 @@ function refreshProfileList(cb) {
 function showAddProfile() {
   // Clear current profile
   currentprofile = null;
+  currentuid = null;
   // Clear form data before show
   $('#profile-name').val('');
   $('#profile-desc').val('');
@@ -292,6 +293,10 @@ function saveProfile() {
   if (!$('#profile-priority').val()) {
     addFormError('profile-priority', _('Priority is required'));
     return
+  }
+
+  if (currentuid === null) {
+    currentuid = $('#profile-name').val();
   }
 
   var data = {


### PR DESCRIPTION
At the moment currentuid is populated with some value only on
edit an existing profile. The same should be made on creating a
new one. For now, this value is applied for storing a profile in AD.