### PR TITLE
Fix logging value of renamed profile name

### DIFF
--- a/admin/fleetcommander/fcdbus.py
+++ b/admin/fleetcommander/fcdbus.py
@@ -576,7 +576,7 @@ class FleetCommanderDbusService(dbus.service.Object):
         if 'oldname' in data:
             logging.debug(
                 'Profile is being renamed from %s to %s' % (
-                    data['oldname'], cn))
+                    data['oldname'], name))
             profile['oldname'] = data['oldname']
 
         try:


### PR DESCRIPTION
As for now the name of new (renamed) profile in a log is the same as an old one:
```
FC: [DEBUG] Profile is being renamed from test to test
FC: [DEBUG] Saving profile into domain server
FC: [DEBUG] FreeIPAConnector: Profile needs renaming from test to test_
```

In fact, "name" keeps a new name of the profile.