### PR TITLE
Fix cockpit plugin AppStream metadata

### DIFF
--- a/data/org.freedesktop.FleetCommander.admin.metainfo.xml
+++ b/data/org.freedesktop.FleetCommander.admin.metainfo.xml
@@ -1,11 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
   <id>org.freedesktop.FleetCommander.admin</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Fleet Commander</name>
   <icon type="local">/usr/share/pixmaps/fc-admin.png</icon>
-  <summary>
-    Manage desktop configuration for a large network
-  </summary>
+  <summary>Manage desktop configuration for a large network</summary>
   <description>
     <p>
       Fleet Commander is an application that allows you to manage the
@@ -14,6 +13,7 @@
       based on the GNOME desktop.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">fleet-commander-admin</launchable>
+  <url type="homepage">https://fleet-commander.org/</url>
 </component>


### PR DESCRIPTION
 * Add missing <?xml> header
 * Update `<extends>` to renamed cockpit ID, as "cockpit.desktop" is
   invalid (§ 2.1.3 [1]) and got changed in [2]
 * Avoid whitespace in `<summary>`
 * Add homepage URL

`appstream-util validate-relax data/org.freedesktop.FleetCommander.admin.metainfo.xml`
is happy now. `validate` only warns about a missing <update_contact>,
but this is optional.

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent
[2] https://github.com/cockpit-project/cockpit/pull/11557