### PR TITLE
Correctly parse SSH host:port specification

### DIFF
--- a/admin/fleetcommander/fcdbus.py
+++ b/admin/fleetcommander/fcdbus.py
@@ -45,7 +45,7 @@ from . import fcad
 
 SYSTEM_USER_REGEX = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]{0,30}$')
 IPADDRESS_AND_PORT_REGEX = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\:[0-9]{1,5})*$')
-HOSTNAME_AND_PORT_REGEX = re.compile(r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(\:[0-9]{1,5})*$')
+HOSTNAME_AND_PORT_REGEX = re.compile(r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(\:[0-9]{1,5})?$')
 
 DBUS_BUS_NAME = 'org.freedesktop.FleetCommander'
 DBUS_OBJECT_PATH = '/org/freedesktop/FleetCommander'
@@ -302,7 +302,7 @@ class FleetCommanderDbusService(dbus.service.Object):
             'Started session checking')
 
     def parse_hypervisor_hostname(self, hostname):
-        hostdata = hostname.split()
+        hostdata = hostname.split(':', maxsplit=1)
         if len(hostdata) == 2:
             host, port = hostdata
         else:


### PR DESCRIPTION
As for now, the specification of SSH port for connections is
ambiguous in FC as one part of code requires 'host port', while
another 'host:port'. From now on, the only supported by FC
specification of SSH port for connections is 'host:port'.

Fixes: https://github.com/fleet-commander/fc-admin/issues/243