### PR TITLE
tests: Make use of sorting of XML attributes

### DIFF
--- a/tests/04_libvirt_controller.py
+++ b/tests/04_libvirt_controller.py
@@ -49,6 +49,7 @@ class TestLibVirtControllerSystemMode(unittest.TestCase):
 
     def setUp(self):
         self.test_directory = tempfile.mkdtemp(prefix='fc-libvirt-test-%s-' % self.LIBVIRT_MODE)
+        self.maxDiff = None
 
         self.config = {
             'data_path': self.test_directory,

--- a/tests/libvirtmock.py
+++ b/tests/libvirtmock.py
@@ -31,18 +31,31 @@ sys.path.append(PYTHONPATH)
 from fleetcommander.database import BaseDBManager, SQLiteDict
 
 
+def _xmltree_sort(root):
+    for el in root.iter():
+        attrib = el.attrib
+        if len(attrib) > 1:
+            attribs = sorted(attrib.items())
+            attrib.clear()
+            attrib.update(attribs)
+
+
+def _xmltree_to_string(xml_path):
+    tree = ET.parse(xml_path)
+    tree = tree.getroot()
+    _xmltree_sort(tree)
+    return ET.tostring(tree).decode()
+
+
 # Preload needed files
-with open(os.path.join(os.environ['TOPSRCDIR'], 'tests/data/libvirt_domain-orig.xml')) as fd:
-    XML_ORIG = fd.read()
-    fd.close()
+XML_ORIG = _xmltree_to_string(os.path.join(os.environ['TOPSRCDIR'],
+                              'tests/data/libvirt_domain-orig.xml'))
 
-with open(os.path.join(os.environ['TOPSRCDIR'], 'tests/data/libvirt_domain-modified.xml')) as fd:
-    XML_MODIF = fd.read()
-    fd.close()
+XML_MODIF = _xmltree_to_string(os.path.join(os.environ['TOPSRCDIR'],
+                               'tests/data/libvirt_domain-modified.xml'))
 
-with open(os.path.join(os.environ['TOPSRCDIR'], 'tests/data/libvirt_domain-nospice.xml')) as fd:
-    XML_NO_SPICE = fd.read()
-    fd.close()
+XML_NO_SPICE = _xmltree_to_string(os.path.join(os.environ['TOPSRCDIR'],
+                                  'tests/data/libvirt_domain-nospice.xml'))
 
 TEST_UUID_SPICE = 'e2e3ad2a-7c2d-45d9-b7bc-fefb33925a81'
 TEST_UUID_NO_SPICE = '0999a0ee-a4c4-11e5-b3a5-68f728db19d3'
@@ -128,9 +141,10 @@ class LibvirtDomainMocker(object):
         self.domain_name = root.find('name').text
         self.domain_title = root.find('title').text
         self.domain_uuid = root.find('uuid').text
-        self.xmldata = ET.tostring(root).decode()
         self.active = True
         self.transient = False
+        _xmltree_sort(root)
+        self.xmldata = ET.tostring(root).decode()
 
     def UUIDString(self):
         return self.domain_uuid


### PR DESCRIPTION
https://docs.python.org/3/library/xml.etree.elementtree.html

> Prior to Python 3.8, the serialisation order of the XML attributes of
elements was artificially made predictable by sorting the attributes by
their name. Based on the now guaranteed ordering of dicts, this
arbitrary reordering was removed in Python 3.8 to preserve the order in
which attributes were originally parsed or created by user code.

As of Python3.8:
> Canonicalization is a way to normalise XML output in a way that allows
byte-by-byte comparisons and digital signatures. It reduced the freedom
that XML serializers have and instead generates a more constrained XML
representation. The main restrictions regard the placement of namespace
declarations, the ordering of attributes, and ignorable whitespace.

In order to support Python < 3.8 the custom sorting is applied.

Fixes: https://github.com/fleet-commander/fc-admin/issues/248