### PR TITLE
Fix crash firefox_bookmark when removing bookmarks

### DIFF
--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -1212,6 +1212,8 @@ class FirefoxBookmarkLogger(object):
         self.connmgr = connmgr
 
     def submit_config_change(self, id, data):
+        if data is None:
+            return
         # Prepare data:
         deserialized_data = json.loads(data)
         payload_data = {


### PR DESCRIPTION
When removing a bookmark in the firefox, an None-type value is passed in the submit method, where json.loads called from an None-type object and the crash firefox_bookmark.

Reproduction:
On template machine with fc-logger start firefox, run `ps ax | grep firefox_bookmark`, it process will exist. Next remove bookmark in firefox and make previous step, process firefox_bookmark not exist.