### PR TITLE
Python 2 deprecation

### DIFF
--- a/admin/fleetcommander/goa.py
+++ b/admin/fleetcommander/goa.py
@@ -20,7 +20,7 @@
 #          Oliver Gutiérrez <ogutierrez@redhat.com>
 
 from __future__ import absolute_import
-from six.moves.configparser import RawConfigParser, ParsingError
+from configparser import RawConfigParser, ParsingError
 import logging
 
 logger = logging.getLogger(__name__)

--- a/admin/fleetcommander/sshcontroller.py
+++ b/admin/fleetcommander/sshcontroller.py
@@ -25,7 +25,6 @@ import subprocess
 import tempfile
 import logging
 import pexpect
-import six
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +61,7 @@ class SSHController:
             [
                 self.SSH_KEYGEN_COMMAND,
                 "-b",
-                six.text_type(key_size),
+                str(key_size),
                 "-t",
                 "rsa",
                 "-f",
@@ -83,7 +82,7 @@ class SSHController:
             [
                 self.SSH_KEYSCAN_COMMAND,
                 "-p",
-                six.text_type(port),
+                str(port),
                 hostname,
             ],
             stdout=subprocess.PIPE,
@@ -174,7 +173,7 @@ class SSHController:
         ssh_command = [self.SSH_COMMAND]
         # Options
         for k, v in kwargs.items():
-            ssh_command.extend(["-o", "%s=%s" % (k, six.text_type(v))])
+            ssh_command.extend(["-o", "%s=%s" % (k, str(v))])
 
         ssh_command.extend(
             [
@@ -186,7 +185,7 @@ class SSHController:
                 "PasswordAuthentication=no",
                 "{user}@{host}".format(user=username, host=hostname),
                 "-p",
-                six.text_type(port),
+                str(port),
                 command,
             ]
         )
@@ -219,7 +218,7 @@ class SSHController:
         ssh_command = [self.SSH_COMMAND]
         # Options
         for k, v in kwargs.items():
-            ssh_command.extend(["-o", "%s=%s" % (k, six.text_type(v))])
+            ssh_command.extend(["-o", "%s=%s" % (k, str(v))])
 
         ssh_command.extend(
             [
@@ -237,7 +236,7 @@ class SSHController:
                 self.CONTROL_SOCKET,
                 "{user}@{host}".format(user=username, host=hostname),
                 "-p",
-                six.text_type(port),
+                str(port),
             ]
         )
         ssh_command.extend([v for lf in local_forwards for v in ("-L", lf)])
@@ -263,7 +262,7 @@ class SSHController:
         ssh_command = [self.SSH_COMMAND]
         # Options
         for k, v in kwargs.items():
-            ssh_command.extend(["-o", "%s=%s" % (k, six.text_type(v))])
+            ssh_command.extend(["-o", "%s=%s" % (k, str(v))])
 
         ssh_command.extend(
             [
@@ -275,7 +274,7 @@ class SSHController:
                 "PasswordAuthentication=no",
                 "{user}@{host}".format(user=username, host=hostname),
                 "-p",
-                six.text_type(port),
+                str(port),
                 "-S",
                 self.CONTROL_SOCKET,
                 "-O",

--- a/admin/fleetcommander/utils.py
+++ b/admin/fleetcommander/utils.py
@@ -24,11 +24,7 @@
 from __future__ import absolute_import
 import logging
 
-# Compat between Pyhon 2 and 3
-try:
-    from configparser import ConfigParser, ParsingError
-except ImportError:
-    from six.moves.configparser import ConfigParser, ParsingError
+from configparser import ConfigParser, ParsingError
 
 from . import constants
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(fleet-commander-admin, 0.15.1, aruiz@redhat.com)
+AC_INIT(fleet-commander-admin, 0.15.2, aruiz@redhat.com)
 AC_COPYRIGHT([Copyright 2014,2015,2016,2017,2018 Red Hat, Inc.])
 
 AC_PREREQ(2.64)
@@ -44,7 +44,7 @@ AC_SUBST([udevrulesdir])
 # Dependencies #
 ################
 
-AM_PATH_PYTHON([2],, [:])
+AM_PATH_PYTHON([3],, [:])
 AC_PYTHON_MODULE([pexpect], [mandatory])
 AC_PYTHON_MODULE([dbus], [mandatory])
 AC_PYTHON_MODULE([gi], [mandatory])

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(fleet-commander-admin, 0.15.2, aruiz@redhat.com)
+AC_INIT(fleet-commander-admin, 0.16.0, aruiz@redhat.com)
 AC_COPYRIGHT([Copyright 2014,2015,2016,2017,2018 Red Hat, Inc.])
 
 AC_PREREQ(2.64)

--- a/data/fleet-commander-logger.in
+++ b/data/fleet-commander-logger.in
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-/usr/bin/env @PYTHON@ @FCLOGGERPYTHONDIR@/fleet_commander_logger.py $@
+@PYTHON@ @FCLOGGERPYTHONDIR@/fleet_commander_logger.py $@

--- a/fleet-commander-admin.spec
+++ b/fleet-commander-admin.spec
@@ -28,7 +28,6 @@ BuildRequires: python3-dns
 BuildRequires: python3-ldap
 BuildRequires: python3-dbusmock
 BuildRequires: python3-ipalib
-BuildRequires: python3-six
 BuildRequires: NetworkManager-libnm
 BuildRequires: json-glib
 BuildRequires: procps

--- a/fleet-commander-admin.spec
+++ b/fleet-commander-admin.spec
@@ -1,14 +1,9 @@
 Name:           fleet-commander-admin
-Version:        0.15.1
-Release:        2%{?dist}
+Version:        0.15.2
+Release:        1%{?dist}
 Summary:        Fleet Commander
 
-# We use python2 only for EPEL
-%if 0%{?rhel} && 0%{?rhel} < 8
-%global python_interpreter python2
-%else
 %global python_interpreter python3
-%endif
 
 BuildArch: noarch
 
@@ -20,20 +15,12 @@ BuildRequires: dconf
 BuildRequires: desktop-file-utils
 BuildRequires: systemd-devel
 
-%if 0%{?rhel} && 0%{?rhel} < 8
-BuildRequires: python2-devel
-BuildRequires: pexpect
-BuildRequires: pygobject3
-BuildRequires: dbus-python
-BuildRequires: libvirt-python
-%else
 BuildRequires: python3-devel
 BuildRequires: python3-pexpect
 BuildRequires: python3-gobject
 BuildRequires: python3-dbus
 BuildRequires: python3-libvirt
 BuildRequires: python3-samba
-%endif
 
 %if 0%{?with_check}
 BuildRequires: git
@@ -54,16 +41,6 @@ Requires: dconf
 Requires: cockpit
 Requires(preun): systemd
 
-%if 0%{?rhel} && 0%{?rhel} < 8
-Requires: pexpect
-Requires: pygobject3
-Requires: libvirt-python
-Requires: dbus-python
-Requires: python2
-Requires: python2-ipa-desktop-profile-client
-Requires: python2-ipalib >= 4.4.0
-Requires: python2-ipaclient >= 4.4.0
-%else
 Requires: python3
 Requires: python3-pexpect
 Requires: python3-dbus
@@ -75,7 +52,6 @@ Requires: python3-ipa-desktop-profile-client
 Requires: python3-dns
 Requires: python3-samba
 Requires: python3-ldap
-%endif
 
 Provides: bundled(spice-html5)
 
@@ -88,14 +64,10 @@ configuration of a large network of users and workstations/laptops.
 Summary: Logs configuration changes in a session
 License: GPLv2
 
-%if 0%{?rhel} && 0%{?rhel} < 8
-Requires: pygobject3
-Requires: dbus-python
-%else
+
 Requires: python3
 Requires: python3-gobject
 Requires: python3-dbus
-%endif
 
 %description -n fleet-commander-logger
 Logs changes for Fleet Commander virtual sessions. Fleet Commander is an
@@ -158,6 +130,9 @@ install -m 755 -d %{buildroot}/%{_localstatedir}/lib/fleet-commander-admin/profi
 %{_datadir}/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/{c73e87a7-b5a1-4b6f-b10b-0bd70241a64d}.xpi
 
 %changelog
+* Mon Apr 12 2020 Oliver Gutierrez <ogutierrez@redhat.com> - 0.15.2-1
+- Deprecation of Python2
+
 * Mon Jul 27 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.15.1-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
 

--- a/fleet-commander-admin.spec
+++ b/fleet-commander-admin.spec
@@ -1,5 +1,5 @@
 Name:           fleet-commander-admin
-Version:        0.15.2
+Version:        0.16.0
 Release:        1%{?dist}
 Summary:        Fleet Commander
 
@@ -129,7 +129,7 @@ install -m 755 -d %{buildroot}/%{_localstatedir}/lib/fleet-commander-admin/profi
 %{_datadir}/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/{c73e87a7-b5a1-4b6f-b10b-0bd70241a64d}.xpi
 
 %changelog
-* Mon Apr 12 2020 Oliver Gutierrez <ogutierrez@redhat.com> - 0.15.2-1
+* Wed May 19 2021 Oliver Gutierrez <ogutierrez@redhat.com> - 0.16.0-1
 - Deprecation of Python2
 
 * Mon Jul 27 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.15.1-2

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -32,7 +32,6 @@ import dbus
 import dbus.service
 
 from dbus.mainloop.glib import DBusGMainLoop
-from six.moves import range
 
 logger = logging.getLogger(os.path.basename(__file__))
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,8 +27,8 @@ TESTS = \
 
 EXTRA_DIST =                         \
 	$(TESTS)                         \
-	__init__.py                      \
 	python-wrapper.sh                \
+	__init__.py                      \
 	freeipamock.py                   \
 	libvirtmock.py                   \
 	ldapmock.py                      \

--- a/tests/_logger_nm.py
+++ b/tests/_logger_nm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 

--- a/tests/_wait_for_name.py
+++ b/tests/_wait_for_name.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import dbus
 import time
 import sys
-from six.moves import range
 
 if __name__ == "__main__":
     session = dbus.Bus()

--- a/tests/freeipamock.py
+++ b/tests/freeipamock.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 import os
 import logging
 import json
-import six
 
 logger = logging.getLogger(__name__)
 
@@ -148,12 +147,12 @@ class FreeIPACommand:
 
     def user_show(self, user):
         if user in self.data.users:
-            return {u"result": {}, u"value": six.text_type(user), u"summary": None}
+            return {"result": {}, "value": str(user), "summary": None}
         raise FreeIPAErrors.NotFound()
 
     def group_show(self, group):
         if group in self.data.groups:
-            return {u"result": {}, u"value": six.text_type(group), u"summary": None}
+            return {"result": {}, "value": str(group), "summary": None}
         raise FreeIPAErrors.NotFound()
 
     def host_find(self, sizelimit):
@@ -162,16 +161,16 @@ class FreeIPACommand:
         for host in self.data.hosts:
             result.append({"fqdn": (host,)})
         res = {
-            u"count": count,
-            u"summary": u"%s Hosts matched" % count,
-            u"result": tuple(result),
-            u"truncated": False,
+            "count": count,
+            "summary": "%s Hosts matched" % count,
+            "result": tuple(result),
+            "truncated": False,
         }
         return res
 
     def host_show(self, host):
         if host in self.data.hosts:
-            return {u"result": {}, u"value": six.text_type(host), u"summary": None}
+            return {"result": {}, "value": str(host), "summary": None}
         raise FreeIPAErrors.NotFound()
 
     def hostgroup_add(self, hostgroup):
@@ -183,7 +182,7 @@ class FreeIPACommand:
 
     def hostgroup_show(self, hostgroup):
         if hostgroup in self.data.hostgroups:
-            return {u"result": {}, u"value": six.text_type(hostgroup), u"summary": None}
+            return {"result": {}, "value": str(hostgroup), "summary": None}
         raise FreeIPAErrors.NotFound()
 
     def hostgroup_add_member(self, hostgroup, host):
@@ -329,10 +328,10 @@ class FreeIPACommand:
     def deskprofile_find(self, criteria, sizelimit, all):
         count = len(list(self.data.profiles.keys()))
         res = {
-            u"count": count,
-            u"summary": u"%s Desktop Profiles matched" % count,
-            u"result": tuple(self.data.profiles.values()),
-            u"truncated": False,
+            "count": count,
+            "summary": "%s Desktop Profiles matched" % count,
+            "result": tuple(self.data.profiles.values()),
+            "truncated": False,
         }
         return res
 

--- a/tests/python-wrapper.sh
+++ b/tests/python-wrapper.sh
@@ -1,2 +1,2 @@
-#!/bin/env bash
+#!/bin/bash
 exec "$PYTHON" "$@"

--- a/tests/test_freeipa.py
+++ b/tests/test_freeipa.py
@@ -137,9 +137,9 @@ class TestFreeIPA(unittest.TestCase):
     PROFILE_MOD_JSON_DATA = json.dumps(TEST_PROFILE_MOD["settings"])
 
     SAVED_PROFILE_DATA_MOD = {
-        u"cn": (TEST_PROFILE_MOD["name"],),
-        u"description": (TEST_PROFILE_MOD["description"],),
-        u"ipadeskdata": (PROFILE_MOD_JSON_DATA,),
+        "cn": (TEST_PROFILE_MOD["name"],),
+        "description": (TEST_PROFILE_MOD["description"],),
+        "ipadeskdata": (PROFILE_MOD_JSON_DATA,),
     }
 
     SAVED_PROFILERULE_DATA_MOD = {

--- a/tests/test_sshcontroller.py
+++ b/tests/test_sshcontroller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env  python-wrapper.sh
+#!/usr/bin/env python-wrapper.sh
 # -*- coding: utf-8 -*-
 # vi:ts=2 sw=2 sts=2
 


### PR DESCRIPTION
Removed all components that supported python2 from tests and enforced python3 dependency on autotools.