### PR TITLE
Fix lint against new Pylint 2.8

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,8 +52,8 @@ pylint: $(GENERATED_PYTHON_FILES)
 	      -path './rpmbuild' -prune -o \
 	      -name '*.py' -print`; \
 	echo -e "Pylinting files:\n$${FILES}\n"; \
-	pylint --version; \
-	PYTHONPATH=$(top_srcdir):$(top_srcdir)/admin pylint \
+	$(PYTHON) -m pylint --version; \
+	PYTHONPATH=$(top_srcdir):$(top_srcdir)/admin $(PYTHON) -m pylint \
 		--rcfile=$(top_srcdir)/pylintrc \
 		--load-plugins pylint_plugins \
 		$${FILES}

--- a/pylintrc
+++ b/pylintrc
@@ -48,6 +48,9 @@ disable=
     unused-argument,
     wrong-import-order,
     wrong-import-position,
+    consider-using-with,  # pylint 2.8.0, contextmanager is not mandatory
+    consider-using-max-builtin,  # pylint 2.8.0, code can be more readable
+    consider-using-min-builtin,  # pylint 2.8.0, code can be more readable
 
 [REPORTS]
 output-format=colorized

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -18,8 +18,6 @@ jobs:
     - template: templates/${{ variables.CONFIGURE_TEMPLATE }}
     - script: |
         set -e
-        # local PATH for Python packages from PyPI
-        export PATH=${HOME}/.local/bin:${PATH}
         make pylint
       displayName: Pylint sources
     - script: |

--- a/tools/chrome-prefs-extract.py
+++ b/tools/chrome-prefs-extract.py
@@ -27,10 +27,8 @@ from __future__ import absolute_import
 import sys
 import json
 
-inputfile = open(sys.argv[1], "r")
-outputfile = open(sys.argv[2], "wb")
-
-data = json.loads(inputfile.read())
+with open(sys.argv[1], "r") as f:
+    data = json.loads(f.read())
 
 outdata = {}
 for key, value in data.items():
@@ -38,4 +36,5 @@ for key, value in data.items():
         if value["pref_mappings"] and "pref" in value["pref_mappings"][0]:
             outdata[value["pref_mappings"][0]["pref"]] = key
 
-outputfile.write(json.dumps(outdata))
+with open(sys.argv[2], "wb") as f:
+    f.write(json.dumps(outdata))


### PR DESCRIPTION
Fix lint against new Pylint 2.8
    
- replace open with contextmanager where reasonable
- globally ignore `consider-using-with`, `consider-using-min-builtin`
  and `consider-using-max-builtin`
    
Fixes: https://github.com/fleet-commander/fc-admin/issues/271