### PR TITLE
Fixed invalid signature for libsmb.Conn object. Fixes #275

### DIFF
--- a/admin/fleetcommander/fcad.py
+++ b/admin/fleetcommander/fcad.py
@@ -169,9 +169,7 @@ class ADConnector:
         # Connect to SMB using kerberos
         creds.set_kerberos_state(MUST_USE_KERBEROS)
         # Create connection
-        conn = libsmb.Conn(
-            self._get_server_name(), service, lp=parm, creds=creds, sign=False
-        )
+        conn = libsmb.Conn(self._get_server_name(), service, lp=parm, creds=creds)
         return conn
 
     def _load_smb_data(self, gpo_uuid):

--- a/tests/smbmock.py
+++ b/tests/smbmock.py
@@ -29,7 +29,7 @@ TEMP_DIR = None
 
 
 class SMBMock:
-    def __init__(self, servername, service, lp, creds, sign=False):
+    def __init__(self, servername, service, lp, creds):
         logging.debug("SMBMock: Mocking SMB at \\\\%s\\%s", servername, service)
         self.tempdir = TEMP_DIR
         logging.debug("Using temporary directory at %s", self.tempdir)


### PR DESCRIPTION
Removed the sign parameter from the libsmb.Conn object initialization.
