### PR TITLE
Pylint 2.12 fixes

### DIFF
--- a/admin/fleetcommander/database.py
+++ b/admin/fleetcommander/database.py
@@ -98,7 +98,7 @@ class SQLiteDict:
             self.__delitem__(key)
 
         valuetype = type(value).__name__
-        if valuetype not in list(self._SUPPORTED_TYPES.keys()):
+        if valuetype not in self._SUPPORTED_TYPES:
             raise ValueError("Type %s is not supported by SQLiteDict" % valuetype)
 
         if valuetype in self._SERIALIZED_TYPES:

--- a/admin/fleetcommander/fcad.py
+++ b/admin/fleetcommander/fcad.py
@@ -187,10 +187,12 @@ class ADConnector:
         os.mkdir(os.path.join(gpodir, "User"))
         # GPT file
         gpt_contents = "[General]\r\nVersion=0\r\n"
-        with open(os.path.join(gpodir, "GPT.INI"), "w") as fd:
+        with open(os.path.join(gpodir, "GPT.INI"), "w", encoding="utf-8") as fd:
             fd.write(gpt_contents)
 
-        with open(os.path.join(gpodir, "fleet-commander.json"), "w") as fd:
+        with open(
+            os.path.join(gpodir, "fleet-commander.json"), "w", encoding="utf-8"
+        ) as fd:
             fd.write(
                 json.dumps(
                     {

--- a/admin/fleetcommander/fcdbus.py
+++ b/admin/fleetcommander/fcdbus.py
@@ -242,7 +242,7 @@ class FleetCommanderDbusService(dbus.service.Object):
             hostname=None,
             mode="system",
         )
-        with open(ctrlr.public_key_file, "r") as fd:
+        with open(ctrlr.public_key_file, "r", encoding="utf-8") as fd:
             public_key = fd.read().strip()
 
         return public_key

--- a/admin/fleetcommander/fcfreeipa.py
+++ b/admin/fleetcommander/fcfreeipa.py
@@ -249,7 +249,7 @@ class FreeIPAConnector:
             rule = self.get_profile_rule(name)
             applies = self._get_profile_applies_from_rule(rule)
             logger.debug("FreeIPAConnector: Applies after update: %s", applies)
-            if applies["hosts"] == [] and applies["hostgroups"] == []:
+            if not applies["hosts"] and not applies["hostgroups"]:
                 logger.debug("FreeIPAConnector: Setting hostcategory to all")
                 parms["hostcategory"] = "all"
                 try:

--- a/admin/fleetcommander/sshcontroller.py
+++ b/admin/fleetcommander/sshcontroller.py
@@ -99,7 +99,7 @@ class SSHController:
         directory = os.path.dirname(known_hosts_file)
         if not os.path.exists(directory):
             os.makedirs(directory)
-        with open(known_hosts_file, "a") as fd:
+        with open(known_hosts_file, "a", encoding="utf-8") as fd:
             fd.write(key_data)
 
     def add_to_known_hosts(self, known_hosts_file, hostname, port=DEFAULT_SSH_PORT):
@@ -112,7 +112,7 @@ class SSHController:
         """
         if os.path.exists(known_hosts_file):
             # Check if host exists in file
-            with open(known_hosts_file) as fd:
+            with open(known_hosts_file, encoding="utf-8") as fd:
                 lines = fd.readlines()
 
             for line in lines:
@@ -126,7 +126,7 @@ class SSHController:
         Get host SSH fingerprint
         """
         tmpfile = tempfile.mktemp(prefix="fc-ssh-keydata")
-        with open(tmpfile, "w") as fd:
+        with open(tmpfile, "w", encoding="utf-8") as fd:
             fd.write(key_data)
 
         prog = subprocess.Popen(

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -1187,8 +1187,7 @@ class FirefoxLogger:
                     self.monitored_preferences[path] = prefs
                 else:
                     logger.debug("New preferences loaded. Checking for changes")
-                    for preference in prefs:
-                        value = prefs[preference]
+                    for preference, value in prefs.items():
                         if preference in self.monitored_preferences[path]:
                             prev = self.monitored_preferences[path][preference]
                             logger.debug(

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -819,7 +819,7 @@ class ChromiumLogger:
                 dirpath, "fleet-commander-logger/fc-chromium-policies.json"
             )
             try:
-                with open(filepath) as fd:
+                with open(filepath, encoding="utf-8") as fd:
                     contents = fd.read()
                     policy_map = json.loads(contents)
 
@@ -1177,7 +1177,7 @@ class FirefoxLogger:
             if fileobj.query_exists(None):
                 logger.debug("Preference file %s exists. Loading it", path)
                 # data = fileobj.load_contents(None)[1]
-                with open(path) as fd:
+                with open(path, encoding="utf-8") as fd:
                     data = fd.read()
 
                 logger.debug("Preference file %s Loaded. Loading preferences.", path)

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -1159,9 +1159,7 @@ class FirefoxLogger:
             # Exit mainloop if we are testing
             if callable(self.test_profiles_file_updated_cb):
                 logger.debug("Exiting mainloop after testing")
-                # pylint: disable=not-callable
                 self.test_profiles_file_updated_cb()
-                # pylint: enable=not-callable
 
     def _preferences_file_updated(self, monitor, fileobj, otherfile, eventType):
         if eventType == Gio.FileMonitorEvent.CHANGES_DONE_HINT or eventType is None:
@@ -1218,9 +1216,7 @@ class FirefoxLogger:
                 logger.debug("Firefox Preferences file %s is not present (yet)", path)
             if callable(self.test_prefs_file_updated_cb):
                 logger.debug("Exiting mainloop after testing")
-                # pylint: disable=not-callable
                 self.test_prefs_file_updated_cb()
-                # pylint: enable=not-callable
 
     def get_default_profile_path(self):
         keyfile = GLib.KeyFile()

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -1009,7 +1009,7 @@ class ChromiumLogger:
         if leaf["type"] == "url":
             logger.debug("Parsing bookmarks leaf %s", leaf["name"])
             return [json.dumps([path, leaf["id"], leaf["url"], leaf["name"]])]
-        return list()
+        return []
 
     def get_modified_bookmarks(self, bmarks1, bmarks2):
         diff = bmarks2[:]

--- a/pylintrc
+++ b/pylintrc
@@ -51,6 +51,7 @@ disable=
     consider-using-with,  # pylint 2.8.0, contextmanager is not mandatory
     consider-using-max-builtin,  # pylint 2.8.0, code can be more readable
     consider-using-min-builtin,  # pylint 2.8.0, code can be more readable
+    consider-using-f-string,  # pylint 2.11.0, format can be more readable
 
 [REPORTS]
 output-format=colorized

--- a/pylintrc
+++ b/pylintrc
@@ -11,9 +11,17 @@ extension-pkg-whitelist=
 enable=
     all,
     python3,
+    useless-suppression,
 
 disable=
-    I,
+    bad-inline-option,
+    c-extension-no-member,
+    deprecated-pragma,
+    file-ignored,
+    locally-disabled,
+    raw-checker-failed,
+    suppressed-message,
+    use-symbolic-message-instead,
     bad-continuation,
     bad-indentation,
     bad-whitespace,

--- a/tests/_fcdbus_tests.py
+++ b/tests/_fcdbus_tests.py
@@ -149,7 +149,7 @@ class TestDbusService(unittest.TestCase):
         """
         Reads JSON file contents
         """
-        with open(path) as fd:
+        with open(path, encoding="utf-8") as fd:
             data = fd.read()
 
         return json.loads(data)

--- a/tests/_logger_test_suite.py
+++ b/tests/_logger_test_suite.py
@@ -84,7 +84,8 @@ class TestScreenSaverInhibitor(unittest.TestCase):
             inhibitor.screensavers["org.freedesktop.ScreenSaver"]["cookie"] == 9191
         )
         inhibitor.uninhibit()
-        self.assertTrue(inhibitor.screensavers == {})
+        self.assertIsInstance(inhibitor.screensavers, dict)
+        self.assertFalse(inhibitor.screensavers)
 
 
 class TestDconfLogger(unittest.TestCase):

--- a/tests/azure/templates/prepare-lint-fedora.yml
+++ b/tests/azure/templates/prepare-lint-fedora.yml
@@ -7,8 +7,9 @@ steps:
 
     printf "Installing latest Python lint dependencies\n"
     pip install \
-        --user --force \
-        pylint \
+        --user \
+        --ignore-installed \
+        'pylint ~= 2.12.2' \
         black \
   displayName: Install latest Python lint dependencies
 

--- a/tests/directorymock.py
+++ b/tests/directorymock.py
@@ -47,7 +47,7 @@ class DirectoryData:
         if self.datadir is not None:
             path = os.path.join(self.datadir, filename)
             logging.debug("Directory mock exporting data to %s", path)
-            with open(path, "w") as fd:
+            with open(path, "w", encoding="utf-8") as fd:
                 fd.write(self.get_json())
 
             logging.debug("Directory mock data saved to %s", path)

--- a/tests/directorymock.py
+++ b/tests/directorymock.py
@@ -125,4 +125,4 @@ class DirectoryConnector:
 
     def get_profile(self, cn):
         logging.debug("Directory Mock: Getting profile %s", cn)
-        return self.data.profiles.get(cn, dict())
+        return self.data.profiles.get(cn, {})

--- a/tests/freeipamock.py
+++ b/tests/freeipamock.py
@@ -68,7 +68,7 @@ class FreeIPAData:
         if self.datadir is not None:
             path = os.path.join(self.datadir, filename)
             logger.debug("IPAMock exporting data to %s", path)
-            with open(path, "w") as fd:
+            with open(path, "w", encoding="utf-8") as fd:
                 fd.write(self.get_json())
 
             logger.debug("FreeIPA mock data saved to %s", path)

--- a/tests/smbmock.py
+++ b/tests/smbmock.py
@@ -78,7 +78,7 @@ class SMBMock:
                 "fssd": fssd.as_sddl(),
             }
         )
-        with open(aclpath, "w") as fd:
+        with open(aclpath, "w", encoding="utf-8") as fd:
             fd.write(acldata)
 
     def deltree(self, duri):

--- a/tests/test_fcdbus_service.py
+++ b/tests/test_fcdbus_service.py
@@ -78,7 +78,7 @@ class MockLibVirtController(libvirtcontroller.LibVirtTunnelSpice):
 
         self.public_key_file = os.path.join(self.data_dir, "id_rsa.pub")
 
-        with open(self.public_key_file, "w") as fd:
+        with open(self.public_key_file, "w", encoding="utf-8") as fd:
             fd.write("PUBLIC_KEY")
 
         self.session_params = namedtuple(

--- a/tests/test_libvirt_controller.py
+++ b/tests/test_libvirt_controller.py
@@ -178,7 +178,7 @@ class TestLibVirtController:
 
         # Check SSH command
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -208,7 +208,7 @@ class TestLibVirtController:
 
         # Check SSH command
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -243,7 +243,7 @@ class TestLibVirtController:
 
         # Test SSH tunnel close
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -270,7 +270,7 @@ class TestLibVirtController:
         self.assertEqual(remote_runtimedir, "/run/user/1001")
 
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -323,7 +323,7 @@ class TestLibVirtControllerSession(TestLibVirtController):
 
         # Check SSH command
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -400,7 +400,7 @@ class TestLibVirtControllerHTML5(TestLibVirtController):
 
         # Test SSH tunnel opening
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -469,7 +469,7 @@ class TestLibVirtControllerHTML5(TestLibVirtController):
 
         # Test SSH tunnel opening
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         remote_socket_logger = os.path.join(
@@ -553,7 +553,7 @@ class TestLibVirtControllerDirectTLS(TestLibVirtController):
 
         # Test SSH tunnel opening
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -630,7 +630,7 @@ class TestLibVirtControllerDirectTLS(TestLibVirtController):
 
         # Test SSH tunnel opening
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         remote_socket_logger = os.path.join(
@@ -668,7 +668,7 @@ class TestLibVirtControllerDirectTLS(TestLibVirtController):
         self.assertEqual(ca_cert, "FAKE_CA_CERT")
 
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -697,7 +697,7 @@ class TestLibVirtControllerDirectTLS(TestLibVirtController):
         self.assertEqual(spice_cert_subject, "CN=localhost")
 
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -769,7 +769,7 @@ class TestLibVirtControllerDirectPlain(TestLibVirtController):
 
         # Test SSH tunnel opening
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         self.assertEqual(
@@ -844,7 +844,7 @@ class TestLibVirtControllerDirectPlain(TestLibVirtController):
 
         # Test SSH tunnel opening
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             command = fd.read().strip()
 
         remote_socket_logger = os.path.join(

--- a/tests/test_libvirt_controller.py
+++ b/tests/test_libvirt_controller.py
@@ -236,10 +236,8 @@ class TestLibVirtController:
         ctrlr.session_stop(session_params.domain)
 
         # Check domain has been stopped and has been set as transient
-        # pylint: disable=no-member
         self.assertFalse(ctrlr._last_stopped_domain.active)
         self.assertTrue(ctrlr._last_stopped_domain.transient)
-        # pylint: enable=no-member
 
         # Test SSH tunnel close
         self.assertTrue(os.path.exists(self.ssh_parms_file))

--- a/tests/test_logger_chromium.py
+++ b/tests/test_logger_chromium.py
@@ -367,16 +367,24 @@ class TestChromiumLogger(unittest.TestCase):
         # Create local state file
         local_state_data = DEFAULT_LOCAL_STATE_DATA
         local_state_data["profile"]["last_active_profiles"] = sessions
-        with open(os.path.join(TMPDIR, "Local State"), "w") as fd:
+        with open(os.path.join(TMPDIR, "Local State"), "w", encoding="utf-8") as fd:
             fd.write(json.dumps(local_state_data, sort_keys=True))
-        with open(os.path.join(TMPDIR, "Profile 1/Preferences"), "w") as fd:
+        with open(
+            os.path.join(TMPDIR, "Profile 1/Preferences"), "w", encoding="utf-8"
+        ) as fd:
             fd.write(json.dumps(profile1_prefs, sort_keys=True))
-        with open(os.path.join(TMPDIR, "Profile 2/Preferences"), "w") as fd:
+        with open(
+            os.path.join(TMPDIR, "Profile 2/Preferences"), "w", encoding="utf-8"
+        ) as fd:
             fd.write(json.dumps(profile2_prefs, sort_keys=True))
         # Bookmarks data
-        with open(os.path.join(TMPDIR, "Profile 1/Bookmarks"), "w") as fd:
+        with open(
+            os.path.join(TMPDIR, "Profile 1/Bookmarks"), "w", encoding="utf-8"
+        ) as fd:
             fd.write(json.dumps(DEFAULT_BOOKMARKS_DATA, sort_keys=True))
-        with open(os.path.join(TMPDIR, "Profile 2/Bookmarks"), "w") as fd:
+        with open(
+            os.path.join(TMPDIR, "Profile 2/Bookmarks"), "w", encoding="utf-8"
+        ) as fd:
             fd.write(json.dumps(DEFAULT_BOOKMARKS_DATA, sort_keys=True))
 
         return TMPDIR
@@ -413,7 +421,7 @@ class TestChromiumLogger(unittest.TestCase):
         # Add a new session to the Local State file
         local_state_data = DEFAULT_LOCAL_STATE_DATA
         local_state_data["profile"]["last_active_profiles"] = ["Profile 1"]
-        with open(os.path.join(TMPDIR, "Local State"), "w") as fd:
+        with open(os.path.join(TMPDIR, "Local State"), "w", encoding="utf-8") as fd:
             fd.write(json.dumps(local_state_data, sort_keys=True))
 
         # Simulate a local state file modification
@@ -426,7 +434,7 @@ class TestChromiumLogger(unittest.TestCase):
 
         # Add a new session to the Local State file
         local_state_data["profile"]["last_active_profiles"] = ["Profile 1", "Profile 2"]
-        with open(os.path.join(TMPDIR, "Local State"), "w") as fd:
+        with open(os.path.join(TMPDIR, "Local State"), "w", encoding="utf-8") as fd:
             fd.write(json.dumps(local_state_data, sort_keys=True))
 
         # Simulate a local state file modification
@@ -516,7 +524,7 @@ class TestChromiumLogger(unittest.TestCase):
         # Helper method to write prefs and simulate file modified notification
         def write_prefs(clogger, prefs, path):
             # Write a new supported setting to the preferences file 1
-            with open(path, "w") as fd:
+            with open(path, "w", encoding="utf-8") as fd:
                 fd.write(json.dumps(prefs, sort_keys=True))
 
             # Simulate a change in preferences file 1
@@ -581,7 +589,7 @@ class TestChromiumLogger(unittest.TestCase):
         # Helper method to write bookmarks and simulate a file modified notification
         def write_bmarks(clogger, bmarks, path):
             # Write a new supported setting to the preferences file 1
-            with open(path, "w") as fd:
+            with open(path, "w", encoding="utf-8") as fd:
                 fd.write(json.dumps(bmarks, sort_keys=True))
 
             # Simulate a change in preferences file 1

--- a/tests/test_logger_connmgr.py
+++ b/tests/test_logger_connmgr.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(os.path.basename(__file__))
 
 
 def read_file(filename):
-    with open(filename) as fd:
+    with open(filename, encoding="utf-8") as fd:
         return fd.read()
 
 

--- a/tests/test_logger_firefox.py
+++ b/tests/test_logger_firefox.py
@@ -138,7 +138,7 @@ class TestFirefoxLogger(unittest.TestCase):
         pass
 
     def file_set_contents(self, filename, contents):
-        with open(filename, "w") as fd:
+        with open(filename, "w", encoding="utf-8") as fd:
             fd.write(contents)
 
     def setup_test_directory(self, profinit=True, prefsinit=True):

--- a/tests/test_sshcontroller.py
+++ b/tests/test_sshcontroller.py
@@ -79,7 +79,7 @@ class TestSSHController(unittest.TestCase):
         ssh.generate_ssh_keypair(self.private_key_file)
         # Check parameters
         self.assertTrue(os.path.exists(self.ssh_keygen_parms_file))
-        with open(self.ssh_keygen_parms_file) as fd:
+        with open(self.ssh_keygen_parms_file, encoding="utf-8") as fd:
             parms = fd.read()
 
         self.assertEqual(parms, self.SSH_KEYGEN_PARMS % self.private_key_file)
@@ -94,7 +94,7 @@ class TestSSHController(unittest.TestCase):
         self.assertEqual(keys, self.SSH_KEYSCAN_OUTPUT % hostname)
         # Check parameters
         self.assertTrue(os.path.exists(self.ssh_keyscan_parms_file))
-        with open(self.ssh_keyscan_parms_file) as fd:
+        with open(self.ssh_keyscan_parms_file, encoding="utf-8") as fd:
             parms = fd.read()
 
         self.assertEqual(parms, self.SSH_KEYSCAN_PARMS % (port, hostname))
@@ -108,14 +108,14 @@ class TestSSHController(unittest.TestCase):
         ssh.add_to_known_hosts(self.known_hosts_file, hostname, port)
         # Check known hosts file exists
         self.assertTrue(os.path.exists(self.known_hosts_file))
-        with open(self.known_hosts_file) as fd:
+        with open(self.known_hosts_file, encoding="utf-8") as fd:
             keys = fd.read()
 
         # Check keys data
         self.assertEqual(keys, self.SSH_KEYSCAN_OUTPUT % hostname)
         # Add another host
         ssh.add_to_known_hosts(self.known_hosts_file, hostname2, port2)
-        with open(self.known_hosts_file) as fd:
+        with open(self.known_hosts_file, encoding="utf-8") as fd:
             keys = fd.read()
 
         # Check keys data
@@ -134,7 +134,7 @@ class TestSSHController(unittest.TestCase):
         result = ssh.check_known_host(self.known_hosts_file, hostname)
         self.assertFalse(result)
         # Check empty known hosts file
-        open(self.known_hosts_file, "w").close()
+        open(self.known_hosts_file, "wb").close()
         self.assertTrue(os.path.exists(self.known_hosts_file))
         result = ssh.check_known_host(self.known_hosts_file, hostname)
         self.assertFalse(result)
@@ -178,7 +178,7 @@ class TestSSHController(unittest.TestCase):
         )
 
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             parms = fd.read().strip()
 
         self.assertEqual(
@@ -225,7 +225,7 @@ class TestSSHController(unittest.TestCase):
         )
 
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file, "r") as fd:
+        with open(self.ssh_parms_file, "r", encoding="utf-8") as fd:
             parms = fd.read().strip()
 
         self.assertEqual(
@@ -263,7 +263,7 @@ class TestSSHController(unittest.TestCase):
         )
 
         self.assertTrue(os.path.exists(self.ssh_parms_file))
-        with open(self.ssh_parms_file) as fd:
+        with open(self.ssh_parms_file, encoding="utf-8") as fd:
             parms = fd.read().strip()
 
         self.assertEqual(

--- a/tools/chrome-prefs-extract.py
+++ b/tools/chrome-prefs-extract.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 import sys
 import json
 
-with open(sys.argv[1], "r") as f:
+with open(sys.argv[1], "r", encoding="utf-8") as f:
     data = json.loads(f.read())
 
 outdata = {}


### PR DESCRIPTION
fixes for Pylint issues such as:

- `consider-using-f-string`
- `consider-iterating-dictionary`
- `unspecified-encoding`
- `use-implicit-booleaness-not-comparison`
- `use-list-literal`
- `consider-using-dict-items`

Fixes: https://github.com/fleet-commander/fc-admin/issues/279