### PR TITLE
admin: Enable Review button conditionally

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ pylint: $(GENERATED_PYTHON_FILES)
 	FILES=`find $(top_srcdir) \
 	      -type d -exec test -e '{}/__init__.py' \; -print -prune -o \
 	      -path './rpmbuild' -prune -o \
-	      -name '*.py' -print`; \
+	      -name '*.py' -print | sort`; \
 	echo -e "Pylinting files:\n$${FILES}\n"; \
 	$(PYTHON) -m pylint --version; \
 	PYTHONPATH=$(top_srcdir):$(top_srcdir)/admin $(PYTHON) -m pylint \

--- a/admin/cockpit/fleet-commander-admin/livesession.html
+++ b/admin/cockpit/fleet-commander-admin/livesession.html
@@ -126,7 +126,10 @@
             <span class="pull-right">
               <button id="reconnect-to-vm" class="btn btn-secondary" translatable="yes">Reconnect to VM</button>
               <button id="close-live-session" class="btn btn-danger" translatable="yes">Close session</button>
-              <button id="review-changes" class="btn btn-primary" translatable="yes">Review and submit</button>
+              <button id="review-changes" class="btn btn-primary" translatable="yes" disabled>
+                <span class="review-changes-spinner"></span>
+                <span class="review-changes-label">Review and submit</span>
+              </button>
             </span>
           </div>
           <div class="panel-body">

--- a/logger/fleet_commander_logger.py
+++ b/logger/fleet_commander_logger.py
@@ -1159,7 +1159,7 @@ class FirefoxLogger:
             # Exit mainloop if we are testing
             if callable(self.test_profiles_file_updated_cb):
                 logger.debug("Exiting mainloop after testing")
-                self.test_profiles_file_updated_cb()
+                self.test_profiles_file_updated_cb()  # pylint: disable=not-callable
 
     def _preferences_file_updated(self, monitor, fileobj, otherfile, eventType):
         if eventType == Gio.FileMonitorEvent.CHANGES_DONE_HINT or eventType is None:
@@ -1216,7 +1216,7 @@ class FirefoxLogger:
                 logger.debug("Firefox Preferences file %s is not present (yet)", path)
             if callable(self.test_prefs_file_updated_cb):
                 logger.debug("Exiting mainloop after testing")
-                self.test_prefs_file_updated_cb()
+                self.test_prefs_file_updated_cb()  # pylint: disable=not-callable
 
     def get_default_profile_path(self):
         keyfile = GLib.KeyFile()


### PR DESCRIPTION
Bug description:

If fc-logger is not installed on VM template then the behaviour of
fc-admin may confuse users.

During VM session a user makes some changes, see Review and submit
button available/enabled and after clicking on that button wonders that
there are no changes actually made.

This is typical error of setup.

Fix description:

Disable Review button by default and wait for IO with notifier
(initial message of notifier protocol) to enable it. Also
added helpful button tooltip.

Fixes: https://github.com/fleet-commander/fc-admin/issues/282